### PR TITLE
//update to 6.5.13

### DIFF
--- a/Lmod/branches/7.0/Lmod-illumina.spec
+++ b/Lmod/branches/7.0/Lmod-illumina.spec
@@ -2,7 +2,7 @@
 %define release         cm7.0
 %define name            Lmod
 %define secname         Lmod-files
-%define version         6.5.11
+%define version         6.5.13
 %define debug_package   %{nil}
 
 %define rhel6_based %(test -e /etc/redhat-release && grep -q -E '(CentOS|Red Hat Enterprise Linux Server|Scientific Linux) release 6' /etc/redhat-release && echo 1 || echo 0)
@@ -13,7 +13,7 @@
 # %define git_rev     %(git rev-list --count --first-parent HEAD)
 %define git_rev     30
 %define git_tag     %(git describe --always)
-%define lmod_upstream_gitid git-a73639c
+%define lmod_upstream_gitid git-8a2acb6
 
 %if %{rhel6_based}
 %define release %{git_rev}_%{git_tag}_cm%{cmrelease}_el6


### PR DESCRIPTION
Update to 6.5.13. The branch name is incorrect and can be ignored.
