### PR TITLE
7.4.9 is needed in a Bright cluster, for NVV+NV ns

### DIFF
--- a/Lmod-illumina.spec
+++ b/Lmod-illumina.spec
@@ -5,7 +5,7 @@
 %define release         cm7.0
 %define name            Lmod
 %define secname         Lmod-files
-%define version         7.4.8
+%define version         7.4.9
 %define debug_package   %{nil}
 
 %define rhel6_based %(test -e /etc/redhat-release && grep -q -E '(CentOS|Red Hat Enterprise Linux Server|Scientific Linux) release 6' /etc/redhat-release && echo 1 || echo 0)
@@ -21,7 +21,7 @@
 %define git_rev     %(git rev-list master --first-parent | wc -l)
 %endif
 
-%define git_tag     4602298
+%define git_tag     048a821
 %define lmod_upstream_gitid git-%{git_tag}
 
 %if %{rhel6_based}


### PR DESCRIPTION
Due to mixed namespaces of NVV & NV type on Bright clusters, a more complete Lmod implementation is required.

7.4.9 is expected to have sufficient clout to handle it, without stumbling, while asked to load modules.