### PR TITLE
bugfix `.csh` script, avoid leaking variable et al

### DIFF
--- a/007-sh-in-it.csh
+++ b/007-sh-in-it.csh
@@ -1,12 +1,16 @@
 #### Why:  Initiate variable settings in Unix/Linux environments via definitions in YAML, fi. for default $MODULEPATH, LMOD_*, EASYBUILD_* etc
 #### Who:  Fotis Georgatos, 2017, MIT license
-/bin/bash -c 'ls /etc/profile.definitions/{global*,site/*,nodecategory/*,groups/`id -gn`,user/`id -un`}.yml 2>/dev/null' | setenv PARSEFILES "`cat`"
+
+set what = "groups/`id -gn`,user/`id -un`"
+setenv __PARSEFILES "`/bin/bash -c 'ls /etc/profile.definitions/{global*,site/*,nodecategory/*,$what}.yml 2>/dev/null'`"
 
 if ( ! $?__Init_Default_Profile )  then
-  foreach file ($PARSEFILES)
+  foreach file ($__PARSEFILES)
     if ( -f $file ) then
       eval `python /etc/profile.d/007-sh-in-it.xyzzy.py $file|sed 's/^export /setenv /g;s/=\(.*\)/ \1/g'|tr '\n' ';'`
     endif
   end
   setenv __Init_Default_Profile 1
 endif
+
+unsetenv __PARSEFILES

--- a/007-sh-in-it.sh
+++ b/007-sh-in-it.sh
@@ -3,7 +3,7 @@
 PARSEFILES=$(ls /etc/profile.definitions/{global*,site/*,nodecategory/*,groups/`id -gn`,user/`id -un`}.yml 2>/dev/null)
 
 if [ -z "$__Init_Default_Profile" ]; then
-  eval `for i in $PARSEFILES; do python /etc/profile.d/007-sh-in-it.xyzzy.py $i;done`
+  eval `for i in $PARSEFILES; do [[ -f $i ]] && python /etc/profile.d/007-sh-in-it.xyzzy.py $i;done`
   export __Init_Default_Profile=1;
 fi
 


### PR DESCRIPTION
this is needed, otherwise .csh profile script variant isn't as discrete as it should be, during initialization 