### PR TITLE
Ordering at the outer level should not be touched & add support for sitelocal/*.yml

### DIFF
--- a/007-sh-in-it.csh
+++ b/007-sh-in-it.csh
@@ -2,7 +2,7 @@
 #### Who:  Fotis Georgatos, 2017, MIT license
 
 set what = "groups/`id -gn`,user/`id -un`"
-setenv __PARSEFILES "`/bin/bash -c 'ls -f /etc/profile.definitions/{global*,site/*,nodecategory/*,$what}.yml 2>/dev/null'`"
+setenv __PARSEFILES "`/bin/bash -c 'ls -f /etc/profile.definitions/{global*,site/*,sitelocal/*,nodecategory/*,$what}.yml 2>/dev/null'`"
 
 if ( ! $?__Init_Default_Profile ) then
   foreach file ($__PARSEFILES)

--- a/007-sh-in-it.csh
+++ b/007-sh-in-it.csh
@@ -2,7 +2,7 @@
 #### Who:  Fotis Georgatos, 2017, MIT license
 
 set what = "groups/`id -gn`,user/`id -un`"
-setenv __PARSEFILES "`/bin/bash -c 'ls /etc/profile.definitions/{global*,site/*,nodecategory/*,$what}.yml 2>/dev/null'`"
+setenv __PARSEFILES "`/bin/bash -c 'ls -f /etc/profile.definitions/{global*,site/*,nodecategory/*,$what}.yml 2>/dev/null'`"
 
 if ( ! $?__Init_Default_Profile ) then
   foreach file ($__PARSEFILES)

--- a/007-sh-in-it.sh
+++ b/007-sh-in-it.sh
@@ -1,6 +1,6 @@
 #### Why:  Initiate variable settings in Unix/Linux environments via definitions in YAML, fi. for default $MODULEPATH, LMOD_*, EASYBUILD_* etc
 #### Who:  Fotis Georgatos, 2017, MIT license
-__PARSEFILES=$(ls /etc/profile.definitions/{global*,site/*,nodecategory/*,groups/`id -gn`,user/`id -un`}.yml 2>/dev/null)
+__PARSEFILES=$(ls -f /etc/profile.definitions/{global*,site/*,nodecategory/*,groups/`id -gn`,user/`id -un`}.yml 2>/dev/null)
 
 if [ -z "$__Init_Default_Profile" ]; then
   eval `for i in $__PARSEFILES; do [[ -f $i ]] && python /etc/profile.d/007-sh-in-it.xyzzy.py $i;done`

--- a/007-sh-in-it.sh
+++ b/007-sh-in-it.sh
@@ -1,6 +1,6 @@
 #### Why:  Initiate variable settings in Unix/Linux environments via definitions in YAML, fi. for default $MODULEPATH, LMOD_*, EASYBUILD_* etc
 #### Who:  Fotis Georgatos, 2017, MIT license
-__PARSEFILES=$(ls -f /etc/profile.definitions/{global*,site/*,nodecategory/*,groups/`id -gn`,user/`id -un`}.yml 2>/dev/null)
+__PARSEFILES=$(ls -f /etc/profile.definitions/{global*,site/*,sitelocal/*,nodecategory/*,groups/`id -gn`,user/`id -un`}.yml 2>/dev/null)
 
 if [ -z "$__Init_Default_Profile" ]; then
   eval `for i in $__PARSEFILES; do [[ -f $i ]] && python /etc/profile.d/007-sh-in-it.xyzzy.py $i;done`


### PR DESCRIPTION
despite that globing will do the sorting within the directories, outside order should be left untouched; 
fixes need to clarify which variable definition overwrites which other (ie. more generic to more specific)

also. the `.csh` needs some facelift as well [DONE]