### PR TITLE
update buildtest.yml

### DIFF
--- a/test/etc/profile.definitions/site/buildtest.yml
+++ b/test/etc/profile.definitions/site/buildtest.yml
@@ -4,12 +4,11 @@ BUILDTEST:
   BINARY:                          "False"
   CLEAN_BUILD:                     "False"
   EASYBUILD:                       "False"
-  OHPC:                            "False"
-  CONFIGS_REPO:                    $HOME/buildtest-framework/toolkit
-  LOGDIR:                          $HOME
-  TESTDIR:                         $HOME/buildtest
-#  MODULEPATH:                     /eb/2018/commons/modules/all:/eb/2018/Broadwell/redhat/7.3/modules/all:/mynfs/grid/software/moduledomains:/etc/modulefiles:/usr/share/modulefiles:/usr/share/lmod/lmod/modulefiles/Core
-  PREPEND_MODULES:                 "[]"
-  RUN_DIR:                         /tmp/buildtest
+  OHPC:                            "False"  
   SHELL:                           sh
+  MODULEPATH:                      []  
   SUCCESS_THRESHOLD:               1.0
+  LOGDIR:                          /tmp/$USER/buildtest
+  TESTDIR:                         /tmp/$USER/buildtest
+  RUN_DIR:                         /tmp/$USER/buildtest  
+  


### PR DESCRIPTION
no need for `CONFIGS_REPO`, `PREPEND_MODULES`. Reorder the commands.
`BUILDTEST_LOGDIR`, `BUILDTEST_TESTDIR`, `BUILDTEST_RUN_DIR` are now set to `/tmp/$USER/buildtest`